### PR TITLE
close closeable resources and other minor improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.wildfly.core</groupId>
       <artifactId>wildfly-controller-client</artifactId>
-      <version>3.0.0.Beta11</version>
+      <version>2.2.1.Final</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/io/openshift/boosters/GreetingResource.java
+++ b/src/main/java/io/openshift/boosters/GreetingResource.java
@@ -47,13 +47,12 @@ public class GreetingResource {
     @GET
     @Path("/killme")
     public Response killme() {
+        ModelNode op = new ModelNode();
+        op.get("address").setEmptyList();
+        op.get("operation").set("suspend");
 
-        try {
-            ModelNode op = new ModelNode();
-            op.get("address").setEmptyList();
-            op.get("operation").set("suspend");
-
-            ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9990);
+        try (ModelControllerClient client = ModelControllerClient.Factory.create(
+                InetAddress.getByName("localhost"), 9990)) {
             ModelNode response = client.execute(op);
 
             if (response.has("failure-description")) {

--- a/src/main/java/io/openshift/boosters/HealthChecks.java
+++ b/src/main/java/io/openshift/boosters/HealthChecks.java
@@ -23,13 +23,13 @@ public class HealthChecks {
     @Health
     @Path("/health")
     public HealthStatus check() {
-        try {
-            ModelNode op = new ModelNode();
-            op.get("address").setEmptyList();
-            op.get("operation").set("read-attribute");
-            op.get("name").set("suspend-state");
+        ModelNode op = new ModelNode();
+        op.get("address").setEmptyList();
+        op.get("operation").set("read-attribute");
+        op.get("name").set("suspend-state");
 
-            ModelControllerClient client = ModelControllerClient.Factory.create(InetAddress.getByName("localhost"), 9990);
+        try (ModelControllerClient client = ModelControllerClient.Factory.create(
+                InetAddress.getByName("localhost"), 9990)) {
             ModelNode response = client.execute(op);
 
             if (response.has("failure-description")) {


### PR DESCRIPTION
I did a quick review of the booster code and noticed that a lot of closeable resources are never closed. I've personally felt a lot of pain from forgetting to close a `ModelControllerClient`, so I fixed that and the JAX-RS `Client` too.